### PR TITLE
feat: support page matching to use code highlighting

### DIFF
--- a/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
+++ b/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.server.PathContainer;
 import org.springframework.stereotype.Component;
 import org.springframework.util.PropertyPlaceholderHelper;
 import org.springframework.util.RouteMatcher;
+import org.springframework.web.util.pattern.PathPatternParser;
 import org.springframework.web.util.pattern.PathPatternRouteMatcher;
 import org.springframework.web.util.pattern.PatternParseException;
 import org.thymeleaf.context.Contexts;
@@ -39,7 +41,8 @@ public class HighlightJSHeadProcessor implements TemplateHeadProcessor {
     private static final String TEMPLATE_ID_VARIABLE = "_templateId";
 
     private final ReactiveSettingFetcher reactiveSettingFetcher;
-    private final RouteMatcher routeMatcher = new PathPatternRouteMatcher();
+
+    private final RouteMatcher routeMatcher = createRouteMatcher();
 
     @Override
     public Mono<Void> process(ITemplateContext context, IModel model, IElementModelStructureHandler structureHandler) {
@@ -141,5 +144,11 @@ public class HighlightJSHeadProcessor implements TemplateHeadProcessor {
         public List<PathMatchRule> nullSafeRules() {
             return ObjectUtils.defaultIfNull(rules, List.of());
         }
+    }
+
+    RouteMatcher createRouteMatcher() {
+        var parser = new PathPatternParser();
+        parser.setPathOptions(PathContainer.Options.HTTP_PATH);
+        return new PathPatternRouteMatcher(parser);
     }
 }

--- a/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
+++ b/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
@@ -1,16 +1,32 @@
 package run.halo.highlightjs;
 
+import com.google.common.base.Throwables;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.springframework.util.RouteMatcher;
+import org.springframework.web.util.pattern.PathPatternRouteMatcher;
+import org.springframework.web.util.pattern.PatternParseException;
+import org.thymeleaf.context.Contexts;
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.model.IModel;
 import org.thymeleaf.model.IModelFactory;
 import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import org.thymeleaf.web.IWebRequest;
 import reactor.core.publisher.Mono;
 import run.halo.app.plugin.ReactiveSettingFetcher;
 import run.halo.app.theme.dialect.TemplateHeadProcessor;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 
 /**
  * @author ryanwang
@@ -23,16 +39,25 @@ public class HighlightJSHeadProcessor implements TemplateHeadProcessor {
     private static final String TEMPLATE_ID_VARIABLE = "_templateId";
 
     private final ReactiveSettingFetcher reactiveSettingFetcher;
+    private final PathPatternRouteMatcher routeMatcher = new PathPatternRouteMatcher();
 
     @Override
     public Mono<Void> process(ITemplateContext context, IModel model, IElementModelStructureHandler structureHandler) {
-        if (!isContentTemplate(context)) {
-            return Mono.empty();
-        }
-        return reactiveSettingFetcher.fetch("basic", BasicConfig.class).doOnNext(basicConfig -> {
-            final IModelFactory modelFactory = context.getModelFactory();
-            model.add(modelFactory.createText(highlightJsScript(basicConfig.getExtra_languages(), basicConfig.getStyle())));
-        }).doOnError((e) -> log.warn("HighlightJSHeadProcessor process failed", e)).then();
+        return reactiveSettingFetcher.fetch("basic", BasicConfig.class)
+                .doOnNext(basicConfig -> {
+                    if (mismatchedRoute(context, basicConfig) && notContentTemplate(context)) {
+                        return;
+                    }
+
+                    final IModelFactory modelFactory = context.getModelFactory();
+                    String scriptString = highlightJsScript(basicConfig.getExtra_languages(), basicConfig.getStyle());
+                    model.add(modelFactory.createText(scriptString));
+                })
+                .onErrorResume(e -> {
+                    log.error("HighlightJSHeadProcessor process failed", Throwables.getRootCause(e));
+                    return Mono.empty();
+                })
+                .then();
     }
 
     private String highlightJsScript(String extraLanguages, String style) {
@@ -74,14 +99,47 @@ public class HighlightJSHeadProcessor implements TemplateHeadProcessor {
                 """.formatted(style, extraLanguages != null ? extraLanguages : "");
     }
 
-    public boolean isContentTemplate(ITemplateContext context) {
-        return "post".equals(context.getVariable(TEMPLATE_ID_VARIABLE))
-                || "page".equals(context.getVariable(TEMPLATE_ID_VARIABLE));
+    public boolean notContentTemplate(ITemplateContext context) {
+        return !"post".equals(context.getVariable(TEMPLATE_ID_VARIABLE))
+                && !"page".equals(context.getVariable(TEMPLATE_ID_VARIABLE));
+    }
+
+    public boolean mismatchedRoute(ITemplateContext context, BasicConfig basicConfig) {
+        if (!Contexts.isWebContext(context)) {
+            return false;
+        }
+        IWebRequest request = Contexts.asWebContext(context).getExchange().getRequest();
+        String requestPath = request.getRequestPath();
+        RouteMatcher.Route requestRoute = routeMatcher.parseRoute(requestPath);
+
+        return basicConfig.nullSafeRules()
+                .stream()
+                .noneMatch(rule -> isMatchedRoute(requestRoute, rule));
+    }
+
+    private boolean isMatchedRoute(RouteMatcher.Route requestRoute, PathMatchRule rule) {
+        try {
+            return routeMatcher.match(rule.getPathPattern(), requestRoute);
+        } catch (PatternParseException e) {
+            // ignore
+            log.warn("Parse route pattern [{}] failed", rule.getPathPattern(), Throwables.getRootCause(e));
+        }
+        return false;
+    }
+
+    @Data
+    public static class PathMatchRule {
+        private String pathPattern;
     }
 
     @Data
     public static class BasicConfig {
         String extra_languages;
         String style;
+        List<PathMatchRule> rules;
+
+        public List<PathMatchRule> nullSafeRules() {
+            return ObjectUtils.defaultIfNull(rules, List.of());
+        }
     }
 }

--- a/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
+++ b/src/main/java/run/halo/highlightjs/HighlightJSHeadProcessor.java
@@ -39,7 +39,7 @@ public class HighlightJSHeadProcessor implements TemplateHeadProcessor {
     private static final String TEMPLATE_ID_VARIABLE = "_templateId";
 
     private final ReactiveSettingFetcher reactiveSettingFetcher;
-    private final PathPatternRouteMatcher routeMatcher = new PathPatternRouteMatcher();
+    private final RouteMatcher routeMatcher = new PathPatternRouteMatcher();
 
     @Override
     public Mono<Void> process(ITemplateContext context, IModel model, IElementModelStructureHandler structureHandler) {

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -7,6 +7,17 @@ spec:
     - group: basic
       label: 基本设置
       formSchema:
+        - $formkit: repeater
+          name: rules
+          label: 页面匹配规则
+          value: [ ]
+          children:
+            - $formkit: text
+              name: pathPattern
+              label: 路径匹配
+              value: ""
+              validation: required
+              help: 用于匹配页面路径的符合 Ant-style 的表达式 ，如：/archives/**，被匹配的页面将会被添加代码高亮功能
         - $formkit: textarea
           name: extra_languages
           label: 代码块额外高亮语言


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
支持通过页面匹配规则使用代码高亮功能

匹配规则使用 Apache Ant 风格的路径，有三种通配符匹配方法，它们可以组合出很多种灵活的路径模式：
- `?` 匹配任何单字符  
- `*` 匹配 0 或者任意数量的字符  
- `**` 匹配 0 或者更多的层级路径

示例：
- `com/t?st.jsp` — matches com/test.jsp but also com/tast.jsp or com/txst.jsp
- `com/*.jsp` — matches all .jsp files in the com directory
- `com/**/test.jsp` — matches all test.jsp files underneath the com path
- `org/springframework/**/*.jsp` — matches all .jsp files underneath the org/springframework path
- `org/**/servlet/bla.jsp` — matches org/springframework/servlet/bla.jsp but also org/springframework/testing/servlet/bla.jsp and org/servlet/bla.jsp
- `com/{filename:\\w+}.jsp` will match com/test.jsp and assign the value test to the filename variable
#### Which issue(s) this PR fixes:
Fixes #6

#### Does this PR introduce a user-facing change?
```release-note
支持通过页面匹配规则使用代码高亮功能
```
