### PR TITLE
chore: remove deprecated plugin wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,11 @@ plugins {
 }
 
 group 'run.halo.highlightjs'
-sourceCompatibility = JavaVersion.VERSION_17
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
     maven { url 'https://s01.oss.sonatype.org/content/repositories/releases' }
@@ -15,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.6.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.10.0-SNAPSHOT')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'

--- a/src/main/java/run/halo/highlightjs/HighlightJSPlugin.java
+++ b/src/main/java/run/halo/highlightjs/HighlightJSPlugin.java
@@ -1,8 +1,8 @@
 package run.halo.highlightjs;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
 import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
 
 /**
  * @author ryanwang
@@ -11,8 +11,8 @@ import run.halo.app.plugin.BasePlugin;
 @Component
 public class HighlightJSPlugin extends BasePlugin {
 
-    public HighlightJSPlugin(PluginWrapper wrapper) {
-        super(wrapper);
+    public HighlightJSPlugin(PluginContext pluginContext) {
+        super(pluginContext);
     }
 
     @Override

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   enabled: true
   version: 1.0.0
-  requires: ">=2.0.0"
+  requires: ">=2.10.0"
   author:
     name: Halo OSS Team
     website: https://github.com/halo-dev


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用，Halo 2.18.0 版本后将不在支持从 BasePlugin 中获取 PluginWrapper ，也不再支持依赖注入 PluginWrapper，使用 PluginContext 代替

see also https://github.com/halo-dev/halo/pull/6243 for more details

```release-note
None
```